### PR TITLE
MMA-8239 Legg på retry ved read timeouts mot juridisk logg

### DIFF
--- a/core/src/main/java/no/nav/dokdistdpo/consumer/juridisk/JuridiskLoggConsumer.java
+++ b/core/src/main/java/no/nav/dokdistdpo/consumer/juridisk/JuridiskLoggConsumer.java
@@ -2,12 +2,12 @@ package no.nav.dokdistdpo.consumer.juridisk;
 
 import no.nav.dokdistdpo.config.properties.DokdistdpoProperties;
 import no.nav.dokdistdpo.exception.functional.LagreJuridiskLoggFunctionalException;
-import no.nav.dokdistdpo.exception.technical.DokdistdpoTechnicalException;
 import no.nav.dokdistdpo.exception.technical.LagreJuridiskLoggTechnicalException;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
 import static java.lang.String.format;
@@ -31,18 +31,24 @@ public class JuridiskLoggConsumer {
 				.build();
 	}
 
-	@Retryable(retryFor = DokdistdpoTechnicalException.class)
+	@Retryable(retryFor = LagreJuridiskLoggTechnicalException.class)
 	public LoggmeldingResponse lagreJuridisklogg(final LoggmeldingRequest loggmeldingRequest) {
-		return restClient.post()
-				.uri("/api/rest/logg")
-				.header(NAV_CALLID, MDC.get(CALL_ID))
-				.body(loggmeldingRequest)
-				.retrieve()
-				.onStatus(HttpStatusCode::isError, (req, res) -> {
-					if (res.getStatusCode().is4xxClientError()) {
-						throw new LagreJuridiskLoggFunctionalException(format("lagreJuridisklogg feilet funksjonelt med status=%s, feilmelding=%s", res.getStatusCode(), res.getStatusText()));
-					}
-					throw new LagreJuridiskLoggTechnicalException(format("lagreJuridiskLogg feilet teknisk med status=%s, feilmelding=%s", res.getStatusCode(), res.getStatusText()));
-				}).body(LoggmeldingResponse.class);
+		try {
+			return restClient.post()
+					.uri("/api/rest/logg")
+					.header(NAV_CALLID, MDC.get(CALL_ID))
+					.body(loggmeldingRequest)
+					.retrieve()
+					.onStatus(HttpStatusCode::isError, (req, res) -> {
+						if (res.getStatusCode().is4xxClientError()) {
+							throw new LagreJuridiskLoggFunctionalException(format("lagreJuridisklogg feilet funksjonelt med status=%s, feilmelding=%s", res.getStatusCode(), res.getStatusText()));
+						}
+						throw new LagreJuridiskLoggTechnicalException(format("lagreJuridiskLogg feilet teknisk med status=%s, feilmelding=%s", res.getStatusCode(), res.getStatusText()));
+					}).body(LoggmeldingResponse.class);
+		} catch (ResourceAccessException e) {
+			// For å få retry ved følgende feil:
+			// org.springframework.web.client.ResourceAccessException: I/O error on POST request for "https://app.adeo.no/juridisklogg/api/rest/logg": Connection reset
+			throw new LagreJuridiskLoggTechnicalException(format("lagreJuridiskLogg feilet teknisk. Feilmelding=%s", e.getMessage()), e);
+		}
 	}
 }

--- a/core/src/main/java/no/nav/dokdistdpo/exception/technical/LagreJuridiskLoggTechnicalException.java
+++ b/core/src/main/java/no/nav/dokdistdpo/exception/technical/LagreJuridiskLoggTechnicalException.java
@@ -1,7 +1,13 @@
 package no.nav.dokdistdpo.exception.technical;
 
 public class LagreJuridiskLoggTechnicalException extends DokdistdpoTechnicalException {
+
 	public LagreJuridiskLoggTechnicalException(String message) {
 		super(message);
 	}
+
+	public LagreJuridiskLoggTechnicalException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
 }


### PR DESCRIPTION
Oppdateringa av juridisk logg skjer etter at meldinga er sendt til DPO. Dersom juridisk logg feilar vil det hindre at statusen i dokdistadmin blir oppdatert, og i tillegg hamnar meldinga på BOQ som seinare blir resendt.

Retry kan hindre at det blir sendt duplikate sendingar til DPO.